### PR TITLE
Fix: Update path in get_rs_anomaly to correctly locate anomaly.yaml

### DIFF
--- a/utils/robustspot_data_utils.py
+++ b/utils/robustspot_data_utils.py
@@ -73,7 +73,7 @@ def get_rs_anomaly(directory, file):
     :param file: str, the csv file (instance) to query the label for.
     :return: str, the label of the queried instance.
     """
-    anomaly_config = os.path.join(run_directory, 'anomaly.yaml')
+    anomaly_config = os.path.join(directory, 'anomaly.yaml')
     anomaly_config = open(anomaly_config, mode='r', encoding='utf-8')
     anomaly_info = yaml.load(anomaly_config.read(), Loader=yaml.FullLoader)
     anomaly = [d for d in anomaly_info if d['data'] == file][0]


### PR DESCRIPTION
This pull request includes a change in the `get_rs_anomaly` function in the `utils/robustspot_data_utils.py` file. The change modifies the path used to locate the 'anomaly.yaml' file, replacing `run_directory` with `directory` to properly locate the file.
